### PR TITLE
Link to Kibana logs if a service fails

### DIFF
--- a/server.py
+++ b/server.py
@@ -70,12 +70,16 @@ def last_update(ingest):
     return last_event["createdDate"]
 
 
+def _parse_date(date_string):
+    return dt.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+
 @app.template_filter("format_date")
 def format_date(date_string):
     if not date_string:
         return ""
 
-    d = dt.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
+    d = _parse_date(date_string)
 
     if d.date() == dt.datetime.now().date():
         return d.strftime("today @ %H:%M")
@@ -83,6 +87,44 @@ def format_date(date_string):
         return d.strftime("yesterday @ %H:%M")
     else:
         return d.strftime("%Y-%m-%d @ %H:%M")
+
+
+@app.template_filter("kibana_url")
+def kibana_url(event, api):
+    namespace = {
+        "production": "prod",
+        "staging": "staging",
+    }[api]
+
+    try:
+        service_name = {
+            "Verification (Azure) failed": f"storage-{namespace}-bag-verifier_azure",
+        }[event["description"]]
+        print(service_name)
+    except KeyError:
+        return ""
+
+    event_time = _parse_date(event["createdDate"])
+
+    # Slop to account for timezone weirdness.  Although Kibana stores timestamps
+    # in UTC, searches happen in your local timezone.  For Wellcome devs this
+    # will always be BST, so this is "good enough" for now.
+    #
+    # Actually localising this properly is a faff.
+    search_start = (event_time - dt.timedelta(minutes=85)).strftime("%Y-%m-%dT%H:%M")
+    search_end = (event_time + dt.timedelta(minutes=65)).strftime("%Y-%m-%dT%H:%M")
+
+    firelens_index_pattern = "978cbc80-af0d-11ea-b454-cb894ee8b269"
+
+    return (
+        "https://logging.wellcomecollection.org/app/kibana#/discover?_g="
+        f"(refreshInterval:(pause:!t,value:0),time:(from:'{search_start}',to:'{search_end}'))&"
+        f"_a=(columns:!(log),"
+        # These are very chatty apps and probably not what we wanted -- errors in
+        # these apps don't get surfaced in the ingest inspector.
+        f"filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'{firelens_index_pattern}',key:service_name,params:(query:{service_name}),type:phrase),query:(match_phrase:(service_name:{service_name})))),"
+        f"index:'{firelens_index_pattern}',interval:auto,sort:!(!('@timestamp',desc)))"
+    )
 
 
 @app.route("/ingests/<ingest_id>")

--- a/templates/ingest.html
+++ b/templates/ingest.html
@@ -107,7 +107,17 @@
         <div class="value" style="margin-bottom: 0">
           <ul>
           {% for ev in ingest.events %}
-            <li>{% if "failed" in ev.description %}<strong>{{ ev.description }}</strong>{% else %}{{ ev.description }}{% endif %}</li>
+            <li>
+              {% if "failed" in ev.description %}
+                <strong>{{ ev.description }}</strong>
+                {% set kibana_url = ev|kibana_url(api) %}
+                {% if kibana_url %}
+                  (<a href="{{ kibana_url }}">dev logs</a>)
+                {% endif %}
+              {% else %}
+                {{ ev.description }}
+              {% endif %}
+            </li>
           {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
This is to help devs with debugging unexpected failures – it prefills a couple of the obvious fields you might want to look at in Kibana. It's not perfect, but it should save a few minutes of clicking around each time.